### PR TITLE
Add Android "Copy to Clipboard" Functionality

### DIFF
--- a/Source/AndroidNative/Private/AndroidNativeLibrary.cpp
+++ b/Source/AndroidNative/Private/AndroidNativeLibrary.cpp
@@ -66,3 +66,8 @@ FString UAndroidNativeLibrary::GetExternalPath()
 {
 	return AndroidNativeUtils::CallJavaStaticMethod<FString>(DeviceInfoClassName, "GetExternalPath", FAndroidGameActivity());
 }
+
+void UAndroidNativeLibrary::CopyTextToClipboard(const FString& InText)
+{
+	AndroidNativeUtils::CallJavaStaticMethod<void>(DeviceInfoClassName, "CopyToClipboard", FAndroidGameActivity(), InText);
+}

--- a/Source/AndroidNative/Private/Java/DeviceInfo.java
+++ b/Source/AndroidNative/Private/Java/DeviceInfo.java
@@ -21,6 +21,9 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import android.content.res.Configuration;
 
+import android.content.ClipData;
+import android.content.ClipboardManager;
+
 // NSD Service
 import android.os.IBinder;
 import android.app.Service;
@@ -168,5 +171,19 @@ public class DeviceInfo {
 	@Keep
 	public static String GetLanguageCode()	{
 		return ConfigurationCompat.getLocales(Resources.getSystem().getConfiguration()).get(0).getDefault().toLanguageTag();
+	}
+	
+	@Keep
+	public static void CopyToClipboard(final Activity activity, String text){
+	    Context context = activity;
+	    
+	    // Get the ClipboardManager service
+        ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+                
+        // Create a new ClipData with the specified text
+        ClipData clip = ClipData.newPlainText("label", text);
+                
+        // Set the clipboard's primary clip
+        clipboard.setPrimaryClip(clip);
 	}
 }

--- a/Source/AndroidNative/Public/AndroidNativeLibrary.h
+++ b/Source/AndroidNative/Public/AndroidNativeLibrary.h
@@ -94,4 +94,10 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Android Native Library|Basic")
 	static EAndroidTheme GetCurrentSystemTheme();
+
+	/**
+	 * Copy text to Android clipboard
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Android Native Library|Basic")
+	static void CopyTextToClipboard(const FString& InText);
 };


### PR DESCRIPTION
This PR introduces a function to enable copying text to the clipboard on Android devices. DeviceInfo.Java file edited and add new function to copy text to clipboard to AndroidNativeLibrary class.